### PR TITLE
Swap to `ktfmt` (`googleStyle`) for Kotlin code, but keep `ktlint` for Gradle scripts 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,16 @@
 [![build](https://github.com/will-molloy/java-template/actions/workflows/build.yml/badge.svg?branch=main&event=push)](https://github.com/will-molloy/java-template/actions/workflows/build.yml)
 [![codecov](https://codecov.io/gh/will-molloy/java-template/branch/main/graph/badge.svg)](https://codecov.io/gh/will-molloy/java-template)
 
-template repo for Java/Kotlin projects using Gradle
+template repo for Java/Kotlin Gradle projects
 
 ## Features
 
 - JDK 21 ([Amazon Corretto](https://aws.amazon.com/corretto/))
-- [Gradle 8](https://github.com/gradle/gradle) with Kotlin DSL
+- [Gradle 8](https://github.com/gradle/gradle) (Kotlin DSL)
 - [GitHub Actions](https://github.com/features/actions) CI/CD
-- Automatic code formatting via [Spotless](https://github.com/diffplug/spotless) ([`google-java-format`](https://github.com/google/google-java-format) and [`ktlint`](https://github.com/pinterest/ktlint))
+- Automatic code formatting via [Spotless](https://github.com/diffplug/spotless)
+  - Java: [`google-java-format`](https://github.com/google/google-java-format)
+  - Kotlin: [`ktlint`](https://github.com/pinterest/ktlint) and [`ktfmt`](https://github.com/facebook/ktfmt)
 - Code style analysis via [Checkstyle](https://github.com/checkstyle/checkstyle)
 - Static analysis via [SpotBugs](https://spotbugs.github.io/)
 - Unit and integration test support via [JUnit 5](https://junit.org/junit5/) and [TestSets plugin](https://github.com/unbroken-dome/gradle-testsets-plugin)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ template repo for Java/Kotlin Gradle projects
 - [GitHub Actions](https://github.com/features/actions) CI/CD
 - Automatic code formatting via [Spotless](https://github.com/diffplug/spotless)
   - Java: [`google-java-format`](https://github.com/google/google-java-format)
-  - Kotlin: [`ktlint`](https://github.com/pinterest/ktlint) and [`ktfmt`](https://github.com/facebook/ktfmt)
+  - Kotlin: [`ktfmt`](https://github.com/facebook/ktfmt)
+  - Kotlin Gradle: [`ktlint`](https://github.com/pinterest/ktlint)
 - Code style analysis via [Checkstyle](https://github.com/checkstyle/checkstyle)
 - Static analysis via [SpotBugs](https://spotbugs.github.io/)
 - Unit and integration test support via [JUnit 5](https://junit.org/junit5/) and [TestSets plugin](https://github.com/unbroken-dome/gradle-testsets-plugin)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 
 logger.quiet("Java version: ${JavaVersion.current()}")
+
 logger.quiet("Gradle version: ${gradle.gradleVersion}")
 
 plugins {
@@ -20,9 +21,7 @@ plugins {
 
 allprojects {
   group = "com.willmolloy"
-  repositories {
-    mavenCentral()
-  }
+  repositories { mavenCentral() }
 
   apply(plugin = "java")
   configure<JavaPluginExtension> {
@@ -31,31 +30,33 @@ allprojects {
   }
 
   apply(plugin = "kotlin")
-  configure<KotlinJvmProjectExtension> {
-    jvmToolchain(21)
-  }
+  configure<KotlinJvmProjectExtension> { jvmToolchain(21) }
 
   apply(plugin = "com.diffplug.spotless")
   configure<SpotlessExtension> {
+    // https://github.com/diffplug/spotless/tree/main/plugin-gradle#java
     java {
       removeUnusedImports()
       googleJavaFormat()
       trimTrailingWhitespace()
       endWithNewline()
     }
+    // https://github.com/diffplug/spotless/tree/main/plugin-gradle#kotlin
     kotlin {
       ktlint()
+      ktfmt().googleStyle()
       trimTrailingWhitespace()
       endWithNewline()
     }
     kotlinGradle {
       ktlint().editorConfigOverride(mapOf("ktlint_standard_no-empty-file" to "disabled"))
+      ktfmt().googleStyle()
       trimTrailingWhitespace()
       endWithNewline()
     }
   }
 
-  // TODO this doesn't work on Kotlin, look into Detekt?
+  // TODO Kotlin alternative?
   apply(plugin = "checkstyle")
   configure<CheckstyleExtension> {
     toolVersion = "10.12.0"
@@ -73,9 +74,7 @@ allprojects {
     ignoreFailures.set(false)
     excludeFilter.set(rootProject.file("./spotbugs-exclude.xml"))
   }
-  tasks.withType<SpotBugsTask> {
-    reports.create("html").required.set(true)
-  }
+  tasks.withType<SpotBugsTask> { reports.create("html").required.set(true) }
 
   tasks.withType<Test> {
     maxParallelForks = Runtime.getRuntime().availableProcessors()
@@ -104,22 +103,12 @@ allprojects {
   }
 
   apply(plugin = "jacoco")
-  tasks.withType<JacocoReport> {
-    reports {
-      xml.required.set(true)
-    }
-  }
+  tasks.withType<JacocoReport> { reports { xml.required.set(true) } }
 
   val previewFeatures = emptyList<String>()
-  tasks.withType<JavaCompile> {
-    options.compilerArgs = previewFeatures
-  }
-  tasks.withType<Test> {
-    jvmArgs = previewFeatures
-  }
-  tasks.withType<JavaExec> {
-    jvmArgs = previewFeatures
-  }
+  tasks.withType<JavaCompile> { options.compilerArgs = previewFeatures }
+  tasks.withType<Test> { jvmArgs = previewFeatures }
+  tasks.withType<JavaExec> { jvmArgs = previewFeatures }
 
   dependencies {
     implementation(rootProject.libs.log4j.core)
@@ -137,7 +126,8 @@ allprojects {
       exclude(group = "org.assertj")
       exclude(group = "junit")
       resolutionStrategy {
-        force("com.google.guava:guava:${rootProject.libs.versions.guava.get()}") // exclude android version
+        // exclude android version
+        force("com.google.guava:guava:${rootProject.libs.versions.guava.get()}")
       }
     }
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,6 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 
 logger.quiet("Java version: ${JavaVersion.current()}")
-
 logger.quiet("Gradle version: ${gradle.gradleVersion}")
 
 plugins {
@@ -21,7 +20,9 @@ plugins {
 
 allprojects {
   group = "com.willmolloy"
-  repositories { mavenCentral() }
+  repositories {
+    mavenCentral()
+  }
 
   apply(plugin = "java")
   configure<JavaPluginExtension> {
@@ -30,7 +31,9 @@ allprojects {
   }
 
   apply(plugin = "kotlin")
-  configure<KotlinJvmProjectExtension> { jvmToolchain(21) }
+  configure<KotlinJvmProjectExtension> {
+    jvmToolchain(21)
+  }
 
   apply(plugin = "com.diffplug.spotless")
   configure<SpotlessExtension> {
@@ -42,15 +45,16 @@ allprojects {
       endWithNewline()
     }
     // https://github.com/diffplug/spotless/tree/main/plugin-gradle#kotlin
+    // ktfmt seems better than ktlint (more deterministic/consistent output).
+    // Furthermore, using spotless more for formatting than linting.
+    // However, ktfmt has some weird output with Gradle scripts, so using ktlint for that.
     kotlin {
-      ktlint()
       ktfmt().googleStyle()
       trimTrailingWhitespace()
       endWithNewline()
     }
     kotlinGradle {
       ktlint().editorConfigOverride(mapOf("ktlint_standard_no-empty-file" to "disabled"))
-      ktfmt().googleStyle()
       trimTrailingWhitespace()
       endWithNewline()
     }
@@ -74,7 +78,9 @@ allprojects {
     ignoreFailures.set(false)
     excludeFilter.set(rootProject.file("./spotbugs-exclude.xml"))
   }
-  tasks.withType<SpotBugsTask> { reports.create("html").required.set(true) }
+  tasks.withType<SpotBugsTask> {
+    reports.create("html").required.set(true)
+  }
 
   tasks.withType<Test> {
     maxParallelForks = Runtime.getRuntime().availableProcessors()
@@ -103,12 +109,22 @@ allprojects {
   }
 
   apply(plugin = "jacoco")
-  tasks.withType<JacocoReport> { reports { xml.required.set(true) } }
+  tasks.withType<JacocoReport> {
+    reports {
+      xml.required.set(true)
+    }
+  }
 
   val previewFeatures = emptyList<String>()
-  tasks.withType<JavaCompile> { options.compilerArgs = previewFeatures }
-  tasks.withType<Test> { jvmArgs = previewFeatures }
-  tasks.withType<JavaExec> { jvmArgs = previewFeatures }
+  tasks.withType<JavaCompile> {
+    options.compilerArgs = previewFeatures
+  }
+  tasks.withType<Test> {
+    jvmArgs = previewFeatures
+  }
+  tasks.withType<JavaExec> {
+    jvmArgs = previewFeatures
+  }
 
   dependencies {
     implementation(rootProject.libs.log4j.core)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,9 +45,6 @@ allprojects {
       endWithNewline()
     }
     // https://github.com/diffplug/spotless/tree/main/plugin-gradle#kotlin
-    // ktfmt seems better than ktlint (more deterministic/consistent output).
-    // Furthermore, using spotless more for formatting than linting.
-    // However, ktfmt has some weird output with Gradle scripts, so using ktlint for that.
     kotlin {
       ktfmt().googleStyle()
       trimTrailingWhitespace()

--- a/example-java/build.gradle.kts
+++ b/example-java/build.gradle.kts
@@ -1,7 +1,3 @@
-plugins {
-  alias(libs.plugins.testsets)
-}
+plugins { alias(libs.plugins.testsets) }
 
-testSets {
-  create("integrationTest")
-}
+testSets { create("integrationTest") }

--- a/example-kotlin/src/main/kotlin/com/willmolloy/HelloWorld.kt
+++ b/example-kotlin/src/main/kotlin/com/willmolloy/HelloWorld.kt
@@ -6,6 +6,7 @@ package com.willmolloy
  * @author <a href=https://willmolloy.com>Will Molloy</a>
  */
 class HelloWorld {
+
   fun hello(text: String): String {
     return "Hello $text!"
   }

--- a/example-kotlin/src/test/kotlin/com/willmolloy/HelloWorldTest.kt
+++ b/example-kotlin/src/test/kotlin/com/willmolloy/HelloWorldTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 
 /** Unit tests for [HelloWorld]. */
 class HelloWorldTest {
+
   @Test
   fun `test hello`() {
     assertThat(HelloWorld().hello("world")).isEqualTo("Hello world!")

--- a/example-kotlin/src/test/kotlin/com/willmolloy/HelloWorldTest.kt
+++ b/example-kotlin/src/test/kotlin/com/willmolloy/HelloWorldTest.kt
@@ -3,9 +3,7 @@ package com.willmolloy
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
 
-/**
- * Unit tests for [HelloWorld].
- */
+/** Unit tests for [HelloWorld]. */
 class HelloWorldTest {
   @Test
   fun `test hello`() {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
 rootProject.name = "java-template"
+
 include("example-java")
+
 include("example-kotlin")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,3 @@
 rootProject.name = "java-template"
-
 include("example-java")
-
 include("example-kotlin")


### PR DESCRIPTION
`ktfmt` seems better than `ktlint` (more deterministic/consistent output). Furthermore, using spotless more for formatting than linting.

However, `ktfmt` has some weird output with Gradle scripts, so keeping `ktlint` for that.