### PR TITLE
Queue main builds instead of cancelling, move permissions to job level

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -7,14 +7,13 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
-
-permissions:
-  contents: write
+  cancel-in-progress: false
 
 jobs:
   dependency-submission:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-java-gradle


### PR DESCRIPTION
## Summary
- `build.yml`: conditional `cancel-in-progress` - cancel on PRs, queue on main
- `dependency-submission.yml`: `cancel-in-progress: false` + move permissions from workflow-level to job-level

## Test plan
- [ ] PR CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)